### PR TITLE
Update chemical reactions from neutralization to indicator

### DIFF
--- a/client/src/components/VirtualLab/ChemicalFormulas.tsx
+++ b/client/src/components/VirtualLab/ChemicalFormulas.tsx
@@ -103,8 +103,7 @@ export const ChemicalFormulas: React.FC<ChemicalFormulasProps> = ({
         ],
         reactions: [
           {
-            equation:
-              "HCl(aq) + Phenolphthalein → HCl-Phenolphthalein complex (colorless)",
+            equation: "HCl(aq) + C₂₀H₁₄O₄ → HCl-C₂₀H₁₄O₄ complex (colorless)",
             name: "Acid-Indicator Interaction",
             type: "Indicator Reaction",
             conditions: [

--- a/client/src/components/VirtualLab/ChemicalFormulas.tsx
+++ b/client/src/components/VirtualLab/ChemicalFormulas.tsx
@@ -103,9 +103,10 @@ export const ChemicalFormulas: React.FC<ChemicalFormulasProps> = ({
         ],
         reactions: [
           {
-            equation: "HCl(aq) + NaOH(aq) → NaCl(aq) + H₂O(l)",
-            name: "Acid-Base Neutralization",
-            type: "Neutralization Reaction",
+            equation:
+              "HCl(aq) + Phenolphthalein → HCl-Phenolphthalein complex (colorless)",
+            name: "Acid-Indicator Interaction",
+            type: "Indicator Reaction",
             conditions: [
               "Room temperature",
               "Aqueous solution",

--- a/client/src/components/VirtualLab/ColorMixingSystem.tsx
+++ b/client/src/components/VirtualLab/ColorMixingSystem.tsx
@@ -22,7 +22,7 @@ export const ColorMixingSystem: React.FC<ColorMixingSystemProps> = ({
     "hcl+phenol": {
       name: "Acid-Indicator Interaction",
       color: "#ADD8E6",
-      description: "HCl + Phenolphthalein → Colorless complex",
+      description: "HCl + C₂₀H₁₄O₄ → Colorless complex",
       indicator: "Indicator remains colorless in acidic solution",
     },
     "agno3+hcl": {
@@ -40,8 +40,15 @@ export const ColorMixingSystem: React.FC<ColorMixingSystemProps> = ({
     "phenol+naoh": {
       name: "Indicator Color Change",
       color: "#FFB6C1",
-      description: "Phenolphthalein turns pink in basic solution",
+      description: "C₂₀H₁₄O₄ turns pink in basic solution",
       indicator: "Pink color indicates basic pH",
+    },
+    "hcl+naoh+phenol": {
+      name: "Acid-Base Titration with Indicator",
+      color: "#FFB6C1",
+      description:
+        "HCl + NaOH → NaCl + H₂O (with C₂₀H₁₄O₄ indicator showing endpoint)",
+      indicator: "Color changes from colorless to pink at endpoint",
     },
     "bromothymol+hcl": {
       name: "pH Indicator Change",

--- a/client/src/components/VirtualLab/ColorMixingSystem.tsx
+++ b/client/src/components/VirtualLab/ColorMixingSystem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 interface Chemical {
   id: string;
@@ -13,61 +13,61 @@ interface ColorMixingSystemProps {
   onReactionDetected: (reaction: string) => void;
 }
 
-export const ColorMixingSystem: React.FC<ColorMixingSystemProps> = ({ 
-  chemicals, 
-  onReactionDetected 
+export const ColorMixingSystem: React.FC<ColorMixingSystemProps> = ({
+  chemicals,
+  onReactionDetected,
 }) => {
   // Chemical reaction rules
   const reactions = {
-    'hcl+naoh': {
-      name: 'Acid-Base Neutralization',
-      color: '#E8F5E8',
-      description: 'HCl + NaOH → NaCl + H₂O',
-      indicator: 'pH changes from acidic to neutral'
+    "hcl+phenol": {
+      name: "Acid-Indicator Interaction",
+      color: "#ADD8E6",
+      description: "HCl + Phenolphthalein → Colorless complex",
+      indicator: "Indicator remains colorless in acidic solution",
     },
-    'agno3+hcl': {
-      name: 'Silver Chloride Precipitation',
-      color: '#F5F5F5',
-      description: 'AgNO₃ + HCl → AgCl↓ + HNO₃',
-      indicator: 'White precipitate forms'
+    "agno3+hcl": {
+      name: "Silver Chloride Precipitation",
+      color: "#F5F5F5",
+      description: "AgNO₃ + HCl → AgCl↓ + HNO₃",
+      indicator: "White precipitate forms",
     },
-    'cacl2+naoh': {
-      name: 'Calcium Hydroxide Formation',
-      color: '#F0F8FF',
-      description: 'CaCl₂ + 2NaOH → Ca(OH)₂ + 2NaCl',
-      indicator: 'Milky white solution'
+    "cacl2+naoh": {
+      name: "Calcium Hydroxide Formation",
+      color: "#F0F8FF",
+      description: "CaCl₂ + 2NaOH → Ca(OH)₂ + 2NaCl",
+      indicator: "Milky white solution",
     },
-    'phenol+naoh': {
-      name: 'Indicator Color Change',
-      color: '#FFB6C1',
-      description: 'Phenolphthalein turns pink in basic solution',
-      indicator: 'Pink color indicates basic pH'
+    "phenol+naoh": {
+      name: "Indicator Color Change",
+      color: "#FFB6C1",
+      description: "Phenolphthalein turns pink in basic solution",
+      indicator: "Pink color indicates basic pH",
     },
-    'bromothymol+hcl': {
-      name: 'pH Indicator Change',
-      color: '#FFFF99',
-      description: 'Bromothymol blue turns yellow in acidic solution',
-      indicator: 'Yellow color indicates acidic pH'
-    }
+    "bromothymol+hcl": {
+      name: "pH Indicator Change",
+      color: "#FFFF99",
+      description: "Bromothymol blue turns yellow in acidic solution",
+      indicator: "Yellow color indicates acidic pH",
+    },
   };
 
   const detectReaction = (chemicalIds: string[]): string | null => {
-    const sortedIds = chemicalIds.sort().join('+');
+    const sortedIds = chemicalIds.sort().join("+");
     return reactions[sortedIds as keyof typeof reactions]?.color || null;
   };
 
   const getReactionInfo = (chemicalIds: string[]) => {
-    const sortedIds = chemicalIds.sort().join('+');
+    const sortedIds = chemicalIds.sort().join("+");
     return reactions[sortedIds as keyof typeof reactions] || null;
   };
 
   // Advanced color mixing algorithm
   const mixColors = (chemicals: Chemical[]): string => {
-    if (chemicals.length === 0) return 'transparent';
+    if (chemicals.length === 0) return "transparent";
     if (chemicals.length === 1) return chemicals[0].color;
 
     // Check for specific reactions first
-    const chemicalIds = chemicals.map(c => c.id);
+    const chemicalIds = chemicals.map((c) => c.id);
     const reactionColor = detectReaction(chemicalIds);
     if (reactionColor) {
       const reaction = getReactionInfo(chemicalIds);
@@ -78,30 +78,33 @@ export const ColorMixingSystem: React.FC<ColorMixingSystemProps> = ({
     }
 
     // Default color mixing for non-reactive combinations
-    let r = 0, g = 0, b = 0, totalWeight = 0;
-    
-    chemicals.forEach(chemical => {
+    let r = 0,
+      g = 0,
+      b = 0,
+      totalWeight = 0;
+
+    chemicals.forEach((chemical) => {
       const weight = chemical.amount;
       const color = chemical.color;
-      
+
       // Convert hex to RGB
-      const hex = color.replace('#', '');
+      const hex = color.replace("#", "");
       const rVal = parseInt(hex.substr(0, 2), 16);
       const gVal = parseInt(hex.substr(2, 2), 16);
       const bVal = parseInt(hex.substr(4, 2), 16);
-      
+
       r += rVal * weight;
       g += gVal * weight;
       b += bVal * weight;
       totalWeight += weight;
     });
-    
-    if (totalWeight === 0) return 'transparent';
-    
+
+    if (totalWeight === 0) return "transparent";
+
     r = Math.round(r / totalWeight);
     g = Math.round(g / totalWeight);
     b = Math.round(b / totalWeight);
-    
+
     return `rgb(${r}, ${g}, ${b})`;
   };
 

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -171,6 +171,15 @@ export const Equipment: React.FC<EquipmentProps> = ({
       return "#FF69B4"; // Bright pink
     }
 
+    // HCl + Phenolphthalein combination (acidic solution)
+    if (
+      chemicalIds.includes("hcl") &&
+      chemicalIds.includes("phenol") &&
+      !chemicalIds.includes("naoh")
+    ) {
+      return "#ADD8E6"; // Light blue for HCl + Phenolphthalein in acidic solution
+    }
+
     // Default color mixing
     let r = 0,
       g = 0,

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -727,7 +727,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   .map((c) => {
                     if (c.id === "hcl") return "HCl";
                     if (c.id === "naoh") return "NaOH";
-                    if (c.id === "phenol") return "C₂���H₁₄O₄";
+                    if (c.id === "phenol") return "C₂���H₁��O₄";
                     return "";
                   })
                   .filter(Boolean)
@@ -738,14 +738,14 @@ export const Equipment: React.FC<EquipmentProps> = ({
               {chemicals.some((c) => c.id === "hcl") &&
                 chemicals.some((c) => c.id === "naoh") && (
                   <div className="bg-green-50 border border-green-200 rounded px-2 py-1 mt-2">
-                    <div className="text-green-800 font-bold text-center text-xs">
-                      Neutralization Reaction
+                    <div className="text-blue-800 font-bold text-center text-xs">
+                      Acid-Indicator Reaction
                     </div>
-                    <div className="text-green-700 font-semibold text-center mt-1">
-                      NaOH + HCl → NaCl + H₂O
+                    <div className="text-blue-700 font-semibold text-center mt-1">
+                      HCl + Phenolphthalein → Complex (colorless)
                     </div>
-                    <div className="text-green-600 text-center text-xs mt-1">
-                      Sodium hydroxide + Hydrochloric acid → Salt + Water
+                    <div className="text-blue-600 text-center text-xs mt-1">
+                      Acid solution with pH indicator remains colorless
                     </div>
                   </div>
                 )}

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -727,7 +727,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   .map((c) => {
                     if (c.id === "hcl") return "HCl";
                     if (c.id === "naoh") return "NaOH";
-                    if (c.id === "phenol") return "C₂���H₁��O₄";
+                    if (c.id === "phenol") return "C₂���H₁₄O₄";
                     return "";
                   })
                   .filter(Boolean)
@@ -742,7 +742,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                       Acid-Indicator Reaction
                     </div>
                     <div className="text-blue-700 font-semibold text-center mt-1">
-                      HCl + Phenolphthalein → Complex (colorless)
+                      HCl + C₂₀H₁₄O₄ → Complex (colorless)
                     </div>
                     <div className="text-blue-600 text-center text-xs mt-1">
                       Acid solution with pH indicator remains colorless

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -923,11 +923,22 @@ function VirtualLabApp({
         description: reactionDescription,
         timestamp: new Date().toLocaleTimeString(),
         calculation: {
-          reaction: "HCl + C₂₀H₁₄O₄ → Complex",
-          reactionType: "Acid-Indicator Interaction",
-          balancedEquation:
-            "HCl(aq) + C₂₀H₁₄O₄ → HCl-C₂₀H₁₄O₄ complex (colorless)",
-          products: ["HCl-C₂₀H₁₄O₄ complex (colorless)"],
+          reaction: hasIndicator
+            ? "HCl + NaOH → NaCl + H₂O (with C₂₀H₁₄O₄)"
+            : "HCl + NaOH → NaCl + H₂O",
+          reactionType: hasIndicator
+            ? "Acid-Base Titration with Indicator"
+            : "Acid-Base Neutralization",
+          balancedEquation: hasIndicator
+            ? "HCl(aq) + NaOH(aq) → NaCl(aq) + H₂O(l) [C₂₀H₁₄O₄ endpoint indicator]"
+            : "HCl(aq) + NaOH(aq) → NaCl(aq) + H₂O(l)",
+          products: hasIndicator
+            ? [
+                "Sodium Chloride (NaCl)",
+                "Water (H₂O)",
+                "Color change at endpoint",
+              ]
+            : ["Sodium Chloride (NaCl)", "Water (H₂O)"],
           yield: 95,
           volumeAdded: limitingAmount,
           totalVolume: totalVolume,

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -497,8 +497,30 @@ function VirtualLabApp({
     },
   ];
 
+  // Undo functionality
+  const saveStateToHistory = useCallback(() => {
+    setUndoHistory((prev) => {
+      const newHistory = [...prev, equipmentPositions];
+      // Keep only last 10 states to prevent memory issues
+      return newHistory.slice(-10);
+    });
+  }, [equipmentPositions]);
+
+  const handleUndo = useCallback(() => {
+    if (undoHistory.length > 0) {
+      const previousState = undoHistory[undoHistory.length - 1];
+      setEquipmentPositions(previousState);
+      setUndoHistory((prev) => prev.slice(0, -1));
+      setToastMessage("↩️ Last action undone");
+      setTimeout(() => setToastMessage(null), 2000);
+    }
+  }, [undoHistory]);
+
   const handleEquipmentDrop = useCallback(
     (id: string, x: number, y: number) => {
+      // Save current state before making changes
+      saveStateToHistory();
+
       setEquipmentPositions((prev) => {
         const existing = prev.find((pos) => pos.id === id);
 

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -752,6 +752,9 @@ function VirtualLabApp({
     const chemical = experimentChemicals.find((c) => c.id === chemicalId);
     if (!chemical) return;
 
+    // Save current state before making changes
+    saveStateToHistory();
+
     // Enhanced phenolphthalein handling for conical flask (proper placement)
     if (chemicalId === "phenol" && equipmentId === "conical_flask") {
       setToastMessage(

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1080,7 +1080,7 @@ function VirtualLabApp({
 
     if (!stirrer || !conicalFlask) {
       setToastMessage(
-        "������️ Please place both magnetic stirrer and conical flask!",
+        "�����️ Please place both magnetic stirrer and conical flask!",
       );
       setTimeout(() => setToastMessage(null), 3000);
       return;
@@ -1320,6 +1320,7 @@ function VirtualLabApp({
                 onReset={() => {
                   // Reset all experiment state to initial values
                   setEquipmentPositions([]);
+                  setUndoHistory([]);
                   setResults([]);
                   setIsRunning(false);
                   setCurrentStep(stepNumber);

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -1080,7 +1080,7 @@ function VirtualLabApp({
 
     if (!stirrer || !conicalFlask) {
       setToastMessage(
-        "�����️ Please place both magnetic stirrer and conical flask!",
+        "������️ Please place both magnetic stirrer and conical flask!",
       );
       setTimeout(() => setToastMessage(null), 3000);
       return;
@@ -1345,6 +1345,21 @@ function VirtualLabApp({
                   setTimeout(() => setToastMessage(null), 3000);
                 }}
               />
+
+              {/* Undo Button */}
+              <button
+                onClick={handleUndo}
+                disabled={undoHistory.length === 0}
+                className={`flex items-center space-x-1 px-3 py-1 ml-4 rounded text-xs font-medium transition-colors ${
+                  undoHistory.length === 0
+                    ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+                    : "bg-purple-500 hover:bg-purple-600 text-white"
+                }`}
+                title="Undo last drag & drop action"
+              >
+                <Undo2 size={14} />
+                <span>Undo ({undoHistory.length})</span>
+              </button>
 
               {/* Titration Control Buttons for Acid-Base Experiment */}
               {experimentTitle.includes("Acid-Base") && (

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -70,6 +70,7 @@ interface VirtualLabProps {
   totalSteps: number;
   experimentTitle: string;
   allSteps: ExperimentStep[];
+  onTimerStart?: () => void;
 }
 
 function VirtualLabApp({
@@ -80,6 +81,7 @@ function VirtualLabApp({
   totalSteps,
   experimentTitle,
   allSteps,
+  onTimerStart,
 }: VirtualLabProps) {
   const [equipmentPositions, setEquipmentPositions] = useState<
     EquipmentPosition[]
@@ -957,7 +959,7 @@ function VirtualLabApp({
           ? "Titration with Indicator in Conical Flask"
           : "Neutralization in Conical Flask";
         reactionDescription = hasIndicator
-          ? `${limitingAmount.toFixed(1)}mL titration: HCl + NaOH → NaCl + H₂O (C₂��H₁₄O₄ endpoint indicator)`
+          ? `${limitingAmount.toFixed(1)}mL titration: HCl + NaOH → NaCl + H₂O (C₂��H₁₄O�� endpoint indicator)`
           : `${limitingAmount.toFixed(1)}mL reaction: HCl + NaOH → NaCl + H₂O`;
       }
 
@@ -1017,6 +1019,9 @@ function VirtualLabApp({
 
   const handleStartExperiment = () => {
     setIsRunning(true);
+    if (onTimerStart) {
+      onTimerStart();
+    }
     onStepComplete();
   };
 

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -904,7 +904,7 @@ function VirtualLabApp({
             : "none";
 
       let reactionTitle = "Acid-Indicator Interaction Detected";
-      let reactionDescription = "HCl + C₂₀H₁₄O₄ → Colorless complex";
+      let reactionDescription = "HCl + C₂₀H₁₄O��� → Colorless complex";
 
       // Enhanced messaging for conical flask
       if (equipmentId === "conical_flask") {
@@ -919,11 +919,11 @@ function VirtualLabApp({
         description: reactionDescription,
         timestamp: new Date().toLocaleTimeString(),
         calculation: {
-          reaction: "HCl + Phenolphthalein → Complex",
+          reaction: "HCl + C₂₀H₁₄O₄ → Complex",
           reactionType: "Acid-Indicator Interaction",
           balancedEquation:
-            "HCl(aq) + Phenolphthalein → HCl-Phenolphthalein complex (colorless)",
-          products: ["HCl-Phenolphthalein complex (colorless)"],
+            "HCl(aq) + C₂₀H₁₄O₄ → HCl-C₂₀H₁₄O₄ complex (colorless)",
+          products: ["HCl-C₂₀H₁₄O₄ complex (colorless)"],
           yield: 95,
           volumeAdded: limitingAmount,
           totalVolume: totalVolume,
@@ -948,7 +948,7 @@ function VirtualLabApp({
       // Special toast message for conical flask
       if (equipmentId === "conical_flask") {
         setToastMessage(
-          `🧪 Acid-indicator reaction complete! HCl + Phenolphthalein → Colorless complex`,
+          `🧪 Acid-indicator reaction complete! HCl + C₂₀H₁₄O₄ → Colorless complex`,
         );
         setTimeout(() => setToastMessage(null), 4000);
       }

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -903,13 +903,13 @@ function VirtualLabApp({
             ? "NaOH"
             : "none";
 
-      let reactionTitle = "Acid-Base Neutralization Detected";
-      let reactionDescription = "NaOH + HCl → NaCl + H₂O";
+      let reactionTitle = "Acid-Indicator Interaction Detected";
+      let reactionDescription = "HCl + Phenolphthalein → Colorless complex";
 
       // Enhanced messaging for conical flask
       if (equipmentId === "conical_flask") {
-        reactionTitle = "Neutralization Reaction in Conical Flask";
-        reactionDescription = `${limitingAmount.toFixed(1)}mL reaction: NaOH + HCl → NaCl + H₂O`;
+        reactionTitle = "Acid-Indicator Reaction in Conical Flask";
+        reactionDescription = `${limitingAmount.toFixed(1)}mL reaction: HCl + Phenolphthalein → Colorless complex`;
       }
 
       const result: Result = {
@@ -919,10 +919,11 @@ function VirtualLabApp({
         description: reactionDescription,
         timestamp: new Date().toLocaleTimeString(),
         calculation: {
-          reaction: "NaOH + HCl → NaCl + H₂O",
-          reactionType: "Acid-Base Neutralization",
-          balancedEquation: "NaOH(aq) + HCl(aq) → NaCl(aq) + H₂O(l)",
-          products: ["Sodium Chloride (NaCl)", "Water (H₂O)"],
+          reaction: "HCl + Phenolphthalein → Complex",
+          reactionType: "Acid-Indicator Interaction",
+          balancedEquation:
+            "HCl(aq) + Phenolphthalein → HCl-Phenolphthalein complex (colorless)",
+          products: ["HCl-Phenolphthalein complex (colorless)"],
           yield: 95,
           volumeAdded: limitingAmount,
           totalVolume: totalVolume,
@@ -946,7 +947,9 @@ function VirtualLabApp({
 
       // Special toast message for conical flask
       if (equipmentId === "conical_flask") {
-        setToastMessage(`🧪 Neutralization complete! NaOH + HCl → NaCl + H₂O`);
+        setToastMessage(
+          `🧪 Acid-indicator reaction complete! HCl + Phenolphthalein → Colorless complex`,
+        );
         setTimeout(() => setToastMessage(null), 4000);
       }
     }

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -908,8 +908,12 @@ function VirtualLabApp({
 
       // Enhanced messaging for conical flask
       if (equipmentId === "conical_flask") {
-        reactionTitle = "Acid-Indicator Reaction in Conical Flask";
-        reactionDescription = `${limitingAmount.toFixed(1)}mL reaction: HCl + C₂₀H₁₄O₄ → Colorless complex`;
+        reactionTitle = hasIndicator
+          ? "Titration with Indicator in Conical Flask"
+          : "Neutralization in Conical Flask";
+        reactionDescription = hasIndicator
+          ? `${limitingAmount.toFixed(1)}mL titration: HCl + NaOH → NaCl + H₂O (C₂��H₁₄O₄ endpoint indicator)`
+          : `${limitingAmount.toFixed(1)}mL reaction: HCl + NaOH → NaCl + H₂O`;
       }
 
       const result: Result = {

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -904,12 +904,12 @@ function VirtualLabApp({
             : "none";
 
       let reactionTitle = "Acid-Indicator Interaction Detected";
-      let reactionDescription = "HCl + Phenolphthalein → Colorless complex";
+      let reactionDescription = "HCl + C₂₀H₁₄O₄ → Colorless complex";
 
       // Enhanced messaging for conical flask
       if (equipmentId === "conical_flask") {
         reactionTitle = "Acid-Indicator Reaction in Conical Flask";
-        reactionDescription = `${limitingAmount.toFixed(1)}mL reaction: HCl + Phenolphthalein → Colorless complex`;
+        reactionDescription = `${limitingAmount.toFixed(1)}mL reaction: HCl + C₂₀H₁₄O₄ → Colorless complex`;
       }
 
       const result: Result = {

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -516,6 +516,19 @@ function VirtualLabApp({
     }
   }, [undoHistory]);
 
+  // Keyboard shortcut for undo (Ctrl+Z)
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.ctrlKey && event.key === "z" && !event.shiftKey) {
+        event.preventDefault();
+        handleUndo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleUndo]);
+
   const handleEquipmentDrop = useCallback(
     (id: string, x: number, y: number) => {
       // Save current state before making changes

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -18,6 +18,7 @@ import {
   Thermometer,
   Droplets,
   Erlenmeyer,
+  Undo2,
 } from "lucide-react";
 import type { ExperimentStep } from "@shared/schema";
 
@@ -905,7 +906,7 @@ function VirtualLabApp({
             : "none";
 
       let reactionTitle = "Acid-Indicator Interaction Detected";
-      let reactionDescription = "HCl + C₂₀H₁₄O��� → Colorless complex";
+      let reactionDescription = "HCl + C₂₀H₁���O��� → Colorless complex";
 
       // Enhanced messaging for conical flask
       if (equipmentId === "conical_flask") {

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -83,6 +83,7 @@ function VirtualLabApp({
   const [equipmentPositions, setEquipmentPositions] = useState<
     EquipmentPosition[]
   >([]);
+  const [undoHistory, setUndoHistory] = useState<EquipmentPosition[][]>([]);
   const [selectedChemical, setSelectedChemical] = useState<string | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [results, setResults] = useState<Result[]>([]);

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -71,6 +71,7 @@ interface VirtualLabProps {
   experimentTitle: string;
   allSteps: ExperimentStep[];
   onTimerStart?: () => void;
+  onTimerStop?: () => void;
 }
 
 function VirtualLabApp({
@@ -82,6 +83,7 @@ function VirtualLabApp({
   experimentTitle,
   allSteps,
   onTimerStart,
+  onTimerStop,
 }: VirtualLabProps) {
   const [equipmentPositions, setEquipmentPositions] = useState<
     EquipmentPosition[]
@@ -1334,7 +1336,12 @@ function VirtualLabApp({
               <Controls
                 isRunning={isRunning}
                 onStart={handleStartExperiment}
-                onStop={() => setIsRunning(false)}
+                onStop={() => {
+                  setIsRunning(false);
+                  if (onTimerStop) {
+                    onTimerStop();
+                  }
+                }}
                 onReset={() => {
                   // Reset all experiment state to initial values
                   setEquipmentPositions([]);

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -381,7 +381,6 @@ function VirtualLabApp({
             />
           ),
         },
-        { id: "pipette", name: "25mL Pipette", icon: <Droplets size={36} /> },
         {
           id: "magnetic_stirrer",
           name: "Magnetic Stirrer",
@@ -1031,7 +1030,7 @@ function VirtualLabApp({
 
     if (!stirrer || !conicalFlask) {
       setToastMessage(
-        "���️ Please place both magnetic stirrer and conical flask!",
+        "�����️ Please place both magnetic stirrer and conical flask!",
       );
       setTimeout(() => setToastMessage(null), 3000);
       return;

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -136,7 +136,7 @@ function VirtualLabApp({
         {
           id: "salicylic_acid",
           name: "Salicylic Acid",
-          formula: "C₇H₆O₃",
+          formula: "C₇H₆O���",
           color: "#F8F8FF",
           concentration: "2.0 g",
           volume: 25,
@@ -701,7 +701,12 @@ function VirtualLabApp({
         return [...prev, { id, x: finalX, y: finalY, chemicals: [] }];
       });
     },
-    [experimentTitle, currentGuidedStep, aspirinGuidedSteps],
+    [
+      experimentTitle,
+      currentGuidedStep,
+      aspirinGuidedSteps,
+      saveStateToHistory,
+    ],
   );
 
   const calculateChemicalProperties = (

--- a/client/src/components/VirtualLab/WorkBench.tsx
+++ b/client/src/components/VirtualLab/WorkBench.tsx
@@ -322,38 +322,6 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                   </p>
                 </div>
               </div>
-
-              {/* Quick Controls in Header */}
-              <div className="flex items-center space-x-3">
-                <button
-                  onClick={() => setIsStirring(!isStirring)}
-                  className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    isStirring
-                      ? "bg-white/20 text-white"
-                      : "bg-white/10 text-white/80 hover:bg-white/20"
-                  }`}
-                >
-                  {isStirring ? "Stop Stirring" : "Start Stirring"}
-                </button>
-
-                <button
-                  onClick={() => setIsDropping(!isDropping)}
-                  className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    isDropping
-                      ? "bg-white/20 text-white"
-                      : "bg-white/10 text-white/80 hover:bg-white/20"
-                  }`}
-                >
-                  {isDropping ? "Stop Titrant" : "Start Titrant"}
-                </button>
-
-                <button
-                  onClick={handleReset}
-                  className="px-4 py-2 bg-white/10 hover:bg-white/20 text-white rounded-lg text-sm font-medium transition-colors"
-                >
-                  Reset
-                </button>
-              </div>
             </div>
           </div>
 

--- a/client/src/pages/experiment.tsx
+++ b/client/src/pages/experiment.tsx
@@ -249,6 +249,7 @@ export default function Experiment() {
                 experimentTitle={experiment.title}
                 allSteps={experiment.stepDetails}
                 onTimerStart={() => setIsRunning(true)}
+                onTimerStop={() => setIsRunning(false)}
               />
             </CardContent>
           </Card>

--- a/client/src/pages/experiment.tsx
+++ b/client/src/pages/experiment.tsx
@@ -49,13 +49,6 @@ export default function Experiment() {
     }
   }, [progress]);
 
-  // Auto-start timer when experiment loads
-  useEffect(() => {
-    if (experiment && !isRunning) {
-      setIsRunning(true);
-    }
-  }, [experiment]);
-
   useEffect(() => {
     let interval: NodeJS.Timeout | null = null;
     if (isRunning) {

--- a/client/src/pages/experiment.tsx
+++ b/client/src/pages/experiment.tsx
@@ -255,6 +255,7 @@ export default function Experiment() {
                 totalSteps={experiment.stepDetails.length}
                 experimentTitle={experiment.title}
                 allSteps={experiment.stepDetails}
+                onTimerStart={() => setIsRunning(true)}
               />
             </CardContent>
           </Card>

--- a/client/src/pages/experiment.tsx
+++ b/client/src/pages/experiment.tsx
@@ -49,6 +49,13 @@ export default function Experiment() {
     }
   }, [progress]);
 
+  // Auto-start timer when experiment loads
+  useEffect(() => {
+    if (experiment && !isRunning) {
+      setIsRunning(true);
+    }
+  }, [experiment]);
+
   useEffect(() => {
     let interval: NodeJS.Timeout | null = null;
     if (isRunning) {

--- a/data/experiments.json
+++ b/data/experiments.json
@@ -93,7 +93,6 @@
     "equipment": [
       "50mL Burette",
       "250mL Conical Flask",
-      "25mL Pipette",
       "Pipette Filler",
       "White Tile",
       "Phenolphthalein Indicator",
@@ -111,7 +110,7 @@
       {
         "id": 2,
         "title": "Prepare Sample",
-        "description": "Using a pipette, transfer exactly 25.0mL of the unknown HCl solution into a clean conical flask.",
+        "description": "Transfer exactly 25.0mL of the unknown HCl solution into a clean conical flask.",
         "duration": "5 minutes",
         "completed": false
       },


### PR DESCRIPTION
Updates chemical reaction definitions throughout the virtual lab components:

- Changes reaction from "HCl + NaOH → NaCl + H₂O" to "HCl + C₂₀H₁₄O₄ → HCl-C₂₀H₁₄O₄ complex"
- Updates reaction names from "Acid-Base Neutralization" to "Acid-Indicator Interaction"
- Modifies reaction types from "Neutralization Reaction" to "Indicator Reaction"
- Adds new reaction combinations including HCl+phenol and multi-chemical titrations
- Updates color mixing logic to handle new indicator reactions
- Changes UI text and descriptions to reflect indicator-based reactions
- Adds undo functionality with history tracking and keyboard shortcuts
- Removes 25mL Pipette from equipment list
- Updates chemical formulas and reaction equations in multiple components
- Adds timer start/stop callbacks to VirtualLabApp component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ea0efe31c7b4a06911189a51a88fa40/cosmos-space)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ea0efe31c7b4a06911189a51a88fa40</projectId>-->
<!--<branchName>cosmos-space</branchName>-->