### PR TITLE
Update NaOH color and improve burette solution display

### DIFF
--- a/client/src/components/VirtualLab/Chemical.tsx
+++ b/client/src/components/VirtualLab/Chemical.tsx
@@ -207,7 +207,7 @@ export const chemicalsList = [
     id: "naoh",
     name: "Sodium Hydroxide",
     formula: "NaOH",
-    color: "transparent",
+    color: "#8B5A9B",
     concentration: "0.1 M",
     volume: 50,
   },

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -358,13 +358,13 @@ export const Equipment: React.FC<EquipmentProps> = ({
               }}
             />
 
-            {/* Solution overlay in burette - fills entire tube */}
+            {/* Solution overlay in burette - fills from 42-50mL markings */}
             {chemicals.length > 0 && (
               <div
                 className="absolute top-12 left-1/2 transform -translate-x-1/2 transition-all duration-500"
                 style={{
                   backgroundColor: getMixedColor(),
-                  height: "200px",
+                  height: "48px",
                   width: "18px",
                   opacity: 0.9,
                   borderRadius: "2px 2px 0 0",

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -358,10 +358,10 @@ export const Equipment: React.FC<EquipmentProps> = ({
               }}
             />
 
-            {/* Solution overlay in burette - better centered */}
+            {/* Solution overlay in burette - positioned at top */}
             {chemicals.length > 0 && (
               <div
-                className="absolute bottom-6 left-1/2 transform -translate-x-1/2 rounded-b-lg transition-all duration-500"
+                className="absolute top-12 left-1/2 transform -translate-x-1/2 rounded-t-lg transition-all duration-500"
                 style={{
                   backgroundColor: getMixedColor(),
                   height: `${getSolutionHeight() * 0.6}%`,
@@ -371,7 +371,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                 }}
               >
                 {/* Liquid surface shimmer */}
-                <div className="absolute top-0 left-0 right-0 h-1 bg-white opacity-40 animate-pulse"></div>
+                <div className="absolute bottom-0 left-0 right-0 h-1 bg-white opacity-40 animate-pulse"></div>
               </div>
             )}
 

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -358,22 +358,21 @@ export const Equipment: React.FC<EquipmentProps> = ({
               }}
             />
 
-            {/* Solution overlay in burette - shaped like burette tube */}
+            {/* Solution overlay in burette - fills entire tube */}
             {chemicals.length > 0 && (
               <div
                 className="absolute top-12 left-1/2 transform -translate-x-1/2 transition-all duration-500"
                 style={{
                   backgroundColor: getMixedColor(),
-                  height: `${getSolutionHeight() * 0.6}%`,
+                  height: "200px",
                   width: "18px",
                   opacity: 0.9,
-                  minHeight: "12px",
                   borderRadius: "2px 2px 0 0",
                   clipPath: "polygon(20% 0%, 80% 0%, 85% 100%, 15% 100%)",
                 }}
               >
                 {/* Liquid surface shimmer */}
-                <div className="absolute bottom-0 left-0 right-0 h-1 bg-white opacity-40 animate-pulse"></div>
+                <div className="absolute top-0 left-0 right-0 h-1 bg-white opacity-40 animate-pulse"></div>
               </div>
             )}
 

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -358,21 +358,21 @@ export const Equipment: React.FC<EquipmentProps> = ({
               }}
             />
 
-            {/* Solution overlay in burette - fills up to 30mL mark */}
+            {/* Solution overlay in burette - fills from 50mL to 30mL mark */}
             {chemicals.length > 0 && (
               <div
-                className="absolute bottom-6 left-1/2 transform -translate-x-1/2 transition-all duration-500"
+                className="absolute top-12 left-1/2 transform -translate-x-1/2 transition-all duration-500"
                 style={{
                   backgroundColor: getMixedColor(),
-                  height: "144px",
+                  height: "96px",
                   width: "18px",
                   opacity: 0.9,
-                  borderRadius: "0 0 2px 2px",
-                  clipPath: "polygon(15% 0%, 85% 0%, 80% 100%, 20% 100%)",
+                  borderRadius: "2px 2px 0 0",
+                  clipPath: "polygon(20% 0%, 80% 0%, 85% 100%, 15% 100%)",
                 }}
               >
                 {/* Liquid surface shimmer at 30mL mark */}
-                <div className="absolute top-0 left-0 right-0 h-1 bg-white opacity-40 animate-pulse"></div>
+                <div className="absolute bottom-0 left-0 right-0 h-1 bg-white opacity-40 animate-pulse"></div>
               </div>
             )}
 

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -358,16 +358,18 @@ export const Equipment: React.FC<EquipmentProps> = ({
               }}
             />
 
-            {/* Solution overlay in burette - positioned at top */}
+            {/* Solution overlay in burette - shaped like burette tube */}
             {chemicals.length > 0 && (
               <div
-                className="absolute top-12 left-1/2 transform -translate-x-1/2 rounded-t-lg transition-all duration-500"
+                className="absolute top-12 left-1/2 transform -translate-x-1/2 transition-all duration-500"
                 style={{
                   backgroundColor: getMixedColor(),
                   height: `${getSolutionHeight() * 0.6}%`,
-                  width: "25%",
+                  width: "18px",
                   opacity: 0.9,
                   minHeight: "12px",
+                  borderRadius: "2px 2px 0 0",
+                  clipPath: "polygon(20% 0%, 80% 0%, 85% 100%, 15% 100%)",
                 }}
               >
                 {/* Liquid surface shimmer */}

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -358,20 +358,20 @@ export const Equipment: React.FC<EquipmentProps> = ({
               }}
             />
 
-            {/* Solution overlay in burette - fills up to 50mL mark */}
+            {/* Solution overlay in burette - fills up to 30mL mark */}
             {chemicals.length > 0 && (
               <div
                 className="absolute bottom-6 left-1/2 transform -translate-x-1/2 transition-all duration-500"
                 style={{
                   backgroundColor: getMixedColor(),
-                  height: "240px",
+                  height: "144px",
                   width: "18px",
                   opacity: 0.9,
                   borderRadius: "0 0 2px 2px",
                   clipPath: "polygon(15% 0%, 85% 0%, 80% 100%, 20% 100%)",
                 }}
               >
-                {/* Liquid surface shimmer at 50mL mark */}
+                {/* Liquid surface shimmer at 30mL mark */}
                 <div className="absolute top-0 left-0 right-0 h-1 bg-white opacity-40 animate-pulse"></div>
               </div>
             )}

--- a/client/src/components/VirtualLab/Equipment.tsx
+++ b/client/src/components/VirtualLab/Equipment.tsx
@@ -358,20 +358,20 @@ export const Equipment: React.FC<EquipmentProps> = ({
               }}
             />
 
-            {/* Solution overlay in burette - fills from 42-50mL markings */}
+            {/* Solution overlay in burette - fills up to 50mL mark */}
             {chemicals.length > 0 && (
               <div
-                className="absolute top-12 left-1/2 transform -translate-x-1/2 transition-all duration-500"
+                className="absolute bottom-6 left-1/2 transform -translate-x-1/2 transition-all duration-500"
                 style={{
                   backgroundColor: getMixedColor(),
-                  height: "48px",
+                  height: "240px",
                   width: "18px",
                   opacity: 0.9,
-                  borderRadius: "2px 2px 0 0",
-                  clipPath: "polygon(20% 0%, 80% 0%, 85% 100%, 15% 100%)",
+                  borderRadius: "0 0 2px 2px",
+                  clipPath: "polygon(15% 0%, 85% 0%, 80% 100%, 20% 100%)",
                 }}
               >
-                {/* Liquid surface shimmer */}
+                {/* Liquid surface shimmer at 50mL mark */}
                 <div className="absolute top-0 left-0 right-0 h-1 bg-white opacity-40 animate-pulse"></div>
               </div>
             )}

--- a/client/src/components/VirtualLab/VirtualLabApp.tsx
+++ b/client/src/components/VirtualLab/VirtualLabApp.tsx
@@ -229,7 +229,7 @@ function VirtualLabApp({
           id: "naoh",
           name: "Sodium Hydroxide",
           formula: "NaOH",
-          color: "transparent",
+          color: "#8B5A9B",
           concentration: "0.1 M",
           volume: 50,
         },


### PR DESCRIPTION
Changes made to the virtual lab components:

- Changed Sodium Hydroxide (NaOH) color from "transparent" to "#8B5A9B" (purple) in both Chemical.tsx and VirtualLabApp.tsx
- Updated burette solution overlay positioning from bottom-centered to top-positioned
- Modified solution display dimensions from percentage-based height to fixed 96px height and 18px width
- Added clip-path styling to create tapered burette shape effect
- Updated comment to reflect solution fills from 50mL to 30mL mark
- Repositioned liquid surface shimmer to bottom of solution overlay

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e51585ef770447579938958f847e75a9/aura-home)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e51585ef770447579938958f847e75a9</projectId>-->
<!--<branchName>aura-home</branchName>-->